### PR TITLE
Add fixed dynamic changes option

### DIFF
--- a/src/core/metrics_manager.py
+++ b/src/core/metrics_manager.py
@@ -26,9 +26,9 @@ class MetricsManager:
         max_hops: int,
         topology_file: str,
         functions_sequence: List[str],
-        mean_interval_ms: float,
-        reconnect_interval_ms: float,
-        disconnect_probability: float,
+        mean_disconnection_interval_ms: float,
+        mean_reconnection_interval_ms: float,
+        disconnection_probability: float,
         algorithms: List[str],
         penalty: float,
     ) -> None:
@@ -38,9 +38,9 @@ class MetricsManager:
             max_hops (int): Maximum number of hops allowed.
             topology_file (str): Path to the topology file.
             functions_sequence (List[str]): Sequence of node functions.
-            mean_interval_ms (float): Mean interval for dynamic changes.
-            reconnect_interval_ms (float): Interval for node reconnection.
-            disconnect_probability (float): Probability of node disconnection.
+            mean_disconnection_interval_ms (float): Mean interval for dynamic changes.
+            mean_reconnection_interval_ms (float): Interval for node reconnection.
+            disconnection_probability (float): Probability of node disconnection.
             algorithms (List[str]): List of algorithms used in the simulation.
             penalty (float): Penalty for Q-Routing.
         """
@@ -49,11 +49,11 @@ class MetricsManager:
             "parameters": {
                 "max_hops": max_hops,
                 "algorithms": algorithms,
-                "mean_interval_ms": mean_interval_ms,
-                "reconnect_interval_ms": reconnect_interval_ms,
+                "mean_disconnection_interval_ms": mean_disconnection_interval_ms,
+                "mean_reconnection_interval_ms": mean_reconnection_interval_ms,
                 "topology_file": topology_file,
                 "functions_sequence": [func.value for func in functions_sequence],
-                "disconnect_probability": disconnect_probability,
+                "disconnection_probability": disconnection_probability,
             },
             "total_time": None,
             "runned_at": datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S"),

--- a/src/core/network.py
+++ b/src/core/network.py
@@ -21,9 +21,9 @@ class Network:
         dynamic_change_events (List[int]): List of times when dynamic changes occurred.
         running (bool): Indicates whether the network is running.
         lock (threading.Lock): Lock for thread-safe operations.
-        mean_interval_ms (Optional[float]): Mean interval between dynamic changes.
-        reconnect_interval_ms (Optional[float]): Interval for node reconnection.
-        disconnect_probability (Optional[float]): Probability of node disconnection.
+        mean_disconnection_interval_ms (Optional[float]): Mean interval between dynamic changes.
+        mean_reconnection_interval_ms (Optional[float]): Interval for node reconnection.
+        disconnection_probability (Optional[float]): Probability of node disconnection.
     """
 
     def __init__(self) -> None:
@@ -34,34 +34,34 @@ class Network:
         self.dynamic_change_events: List[int] = []
         self.running: bool = False
         self.lock: threading.Lock = threading.Lock()
-        self.mean_interval_ms: Optional[float] = None
-        self.reconnect_interval_ms: Optional[float] = None
-        self.disconnect_probability: Optional[float] = None
+        self.mean_disconnection_interval_ms: Optional[float] = None
+        self.mean_reconnection_interval_ms: Optional[float] = None
+        self.disconnection_probability: Optional[float] = None
         log.info("Network initialized.")
 
-    def set_mean_interval_ms(self, mean_interval_ms: float) -> None:
+    def set_mean_disconnection_interval_ms(self, mean_disconnection_interval_ms: float) -> None:
         """Sets the mean interval between dynamic changes.
 
         Args:
-            mean_interval_ms (float): Mean interval in milliseconds.
+            mean_disconnection_interval_ms (float): Mean interval in milliseconds.
         """
-        self.mean_interval_ms = mean_interval_ms
+        self.mean_disconnection_interval_ms = mean_disconnection_interval_ms
 
-    def set_reconnect_interval_ms(self, reconnect_interval_ms: float) -> None:
+    def set_mean_reconnection_interval_ms(self, mean_reconnection_interval_ms: float) -> None:
         """Sets the interval for node reconnection.
 
         Args:
-            reconnect_interval_ms (float): Reconnection interval in milliseconds.
+            mean_reconnection_interval_ms (float): Reconnection interval in milliseconds.
         """
-        self.reconnect_interval_ms = reconnect_interval_ms
+        self.mean_reconnection_interval_ms = mean_reconnection_interval_ms
 
-    def set_disconnect_probability(self, disconnect_probability: float) -> None:
+    def set_disconnection_probability(self, disconnection_probability: float) -> None:
         """Sets the probability of node disconnection.
 
         Args:
-            disconnect_probability (float): Probability of disconnection (0.0 to 1.0).
+            disconnection_probability (float): Probability of disconnection (0.0 to 1.0).
         """
-        self.disconnect_probability = disconnect_probability
+        self.disconnection_probability = disconnection_probability
 
     def generate_next_dynamic_change(self) -> int:
         """Generates the next dynamic change time based on an exponential distribution.
@@ -69,9 +69,9 @@ class Network:
         Returns:
             int: Time (ms) for the next dynamic change.
         """
-        if self.mean_interval_ms == float("inf"):
+        if self.mean_disconnection_interval_ms == float("inf"):
             return int(1e12)  # A very large number to simulate no changes
-        return int(np.random.exponential(self.mean_interval_ms))
+        return int(np.random.exponential(self.mean_disconnection_interval_ms))
 
     def start_dynamic_changes(self) -> None:
         """Starts a thread to apply dynamic changes based on the central clock."""
@@ -102,10 +102,10 @@ class Network:
     def trigger_dynamic_change(self) -> None:
         """Applies the logic for dynamic changes in the network (e.g., random node disconnections)."""
         for node_id in list(self.active_nodes):
-            if np.random.rand() < self.disconnect_probability:
+            if np.random.rand() < self.disconnection_probability:
                 self.nodes[node_id].status = False
                 self.nodes[node_id].reconnect_time = np.random.exponential(
-                    scale=self.reconnect_interval_ms
+                    scale=self.mean_reconnection_interval_ms
                 )
 
                 current_time = clock.get_current_time()

--- a/src/core/network.py
+++ b/src/core/network.py
@@ -32,7 +32,7 @@ class Network:
         self.connections: Dict[int, List[int]] = {}
         self.active_nodes: Set[int] = set()
         self.dynamic_change_events: List[int] = []
-        self.running: bool = False
+        self.running: bool = True
         self.lock: threading.Lock = threading.Lock()
         self.mean_disconnection_interval_ms: Optional[float] = None
         self.mean_reconnection_interval_ms: Optional[float] = None
@@ -48,12 +48,28 @@ class Network:
         self.mean_disconnection_interval_ms = mean_disconnection_interval_ms
 
     def set_mean_reconnection_interval_ms(self, mean_reconnection_interval_ms: float) -> None:
-        """Sets the interval for node reconnection.
+        """Sets a mean interval for node reconnection when disconnected.
 
         Args:
-            mean_reconnection_interval_ms (float): Reconnection interval in milliseconds.
+            mean_reconnection_interval_ms (float): Mean reconnection interval in milliseconds.
         """
         self.mean_reconnection_interval_ms = mean_reconnection_interval_ms
+
+    def set_disconnection_interval_ms(self, disconnection_interval_ms: float) -> None:
+        """Sets a fixed interval between dynamic changes.
+
+        Args:
+            disconnection_interval_ms (float): Fixed interval in milliseconds.
+        """
+        self.disconnection_interval_ms = disconnection_interval_ms
+
+    def set_reconnection_interval_ms(self, reconnection_interval_ms: float) -> None:
+        """Sets the fixed interval for node reconnection when disconnected.
+
+        Args:
+            reconnection_interval_ms (float): Fixed reconnection interval in milliseconds.
+        """
+        self.reconnection_interval_ms = reconnection_interval_ms
 
     def set_disconnection_probability(self, disconnection_probability: float) -> None:
         """Sets the probability of node disconnection.
@@ -64,18 +80,20 @@ class Network:
         self.disconnection_probability = disconnection_probability
 
     def generate_next_dynamic_change(self) -> int:
-        """Generates the next dynamic change time based on an exponential distribution.
+        """Generates the next dynamic change time based on configured intervals.
 
         Returns:
             int: Time (ms) for the next dynamic change.
         """
-        if self.mean_disconnection_interval_ms == float("inf"):
+        if hasattr(self, "disconnection_interval_ms") and self.disconnection_interval_ms is not None:
+            return self.disconnection_interval_ms
+        elif self.mean_disconnection_interval_ms == float("inf"):
             return int(1e12)  # A very large number to simulate no changes
-        return int(np.random.exponential(self.mean_disconnection_interval_ms))
+        else:
+            return int(np.random.exponential(self.mean_disconnection_interval_ms))
 
     def start_dynamic_changes(self) -> None:
         """Starts a thread to apply dynamic changes based on the central clock."""
-        self.running = True
         current_time = clock.get_current_time()
         log.info(f"Network clock starts: {current_time}")
         threading.Thread(target=self._monitor_dynamic_changes, daemon=True).start()
@@ -97,37 +115,50 @@ class Network:
                     self.dynamic_change_events.append(current_time)
                     next_event_time = current_time + self.generate_next_dynamic_change()
 
-                self._handle_reconnections(current_time)
+                self._handle_reconnections()
 
     def trigger_dynamic_change(self) -> None:
         """Applies the logic for dynamic changes in the network (e.g., random node disconnections)."""
+        current_time = clock.get_current_time()
+
         for node_id in list(self.active_nodes):
             if np.random.rand() < self.disconnection_probability:
-                self.nodes[node_id].status = False
-                self.nodes[node_id].reconnect_time = np.random.exponential(
-                    scale=self.mean_reconnection_interval_ms
-                )
+                node = self.nodes[node_id]
+                node.status = False
 
-                current_time = clock.get_current_time()
+                # fixed reconnection mode
+                if self.reconnection_interval_ms is not None:
+                    node.disconnected_at = current_time
+                # mean reconnection mode
+                elif self.mean_reconnection_interval_ms is not None:
+                    node.reconnect_time = current_time + np.random.exponential(
+                        scale=self.mean_reconnection_interval_ms
+                    )
+
                 log.warning(f"Node {node_id} disconnected at {current_time:.2f}.")
 
-    def _handle_reconnections(self, current_time: int) -> None:
-        """Handles reconnections of previously disconnected nodes.
+    def _handle_reconnections(self) -> None:
+        """Handles reconnections of previously disconnected nodes."""
+        current_time = clock.get_current_time()
 
-        Args:
-            current_time (int): Current simulation time in milliseconds.
-        """
         for node_id, node in self.nodes.items():
-            if (
-                not node.status
-                and node.reconnect_time is not None
-                and current_time >= node.reconnect_time
-            ):
-                node.status = True
-                node.reconnect_time = None
-
-                current_time = clock.get_current_time()
-                log.info(f"Node {node_id} reconnected at {current_time:.2f}.")
+            if not node.status:
+                # Fixed reconnection mode
+                if self.reconnection_interval_ms is not None:
+                    if not hasattr(node, "disconnected_at") or node.disconnected_at is None:
+                        continue
+                    if current_time >= node.disconnected_at + self.reconnection_interval_ms:
+                        node.status = True
+                        delattr(node, "disconnected_at")
+                        log.info(f"Node {node_id} reconnected at {current_time:.2f}.")
+                # Mean reconnection mode
+                elif self.mean_reconnection_interval_ms is not None:
+                    if not hasattr(node, "reconnect_time"):
+                        node.reconnect_time = current_time + np.random.exponential(self.mean_reconnection_interval_ms)
+                    if current_time >= node.reconnect_time:
+                        node.status = True
+                        delattr(node, "reconnect_time")
+                        log.info(f"Node {node_id} reconnected at {current_time:.2f}.")
 
     def validate_connection(self, from_node_id: int, to_node_id: int) -> bool:
         """Validates if a connection between two nodes is valid.

--- a/src/core/node.py
+++ b/src/core/node.py
@@ -35,8 +35,8 @@ class Node:
         self.network: "Network" = network
         self.application: Optional["Application"] = None
         self.is_sender: bool = False
-        self.lifetime: Optional[float] = None
         self.reconnect_time: Optional[float] = None
+        self.disconnected_at: Optional[float] = None
         self.status: Optional[bool] = None
         self.position: Optional[Tuple[float, float, float]] = position
         log.info(f"Node {node_id} initialized.")
@@ -80,30 +80,6 @@ class Node:
         if self.application and hasattr(self.application, "get_assigned_function"):
             return self.application.get_assigned_function()
         return "N/A"
-
-    def update_status(self) -> bool:
-        """Updates the status of the node based on its lifetime and reconnect time.
-
-        Returns:
-            bool: The updated status of the node (True = active, False = inactive).
-        """
-        if not self.is_sender:
-            if self.status:
-                self.lifetime -= 1
-
-                if self.lifetime <= 0:
-                    self.status = False
-                    self.reconnect_time = np.random.exponential(scale=2)
-                    log.warning(f"Node {self.node_id} disconnected.")
-            else:
-                self.reconnect_time -= 1
-
-                if self.reconnect_time <= 0:
-                    self.status = True
-                    self.lifetime = np.random.exponential(scale=2)
-                    log.info(f"Node {self.node_id} reconnected.")
-
-        return self.status
 
     def __str__(self) -> str:
         """Returns a string representation of the node.

--- a/src/main.py
+++ b/src/main.py
@@ -22,7 +22,7 @@
 # learning for optimized packet routing in ESP-based mesh networks.
 #
 # The source code for this project is available at:
-# https://github.com/pablotrrs/py-q-mesh-routing
+# https://github.com/pablotrrs/mesh-routing-lab
 
 import argparse
 import logging as log
@@ -63,22 +63,22 @@ def setup_arguments():
         help="Maximum number of hops allowed for each episode (default: 10)",
     )
     parser.add_argument(
-        "--mean_interval_ms",
+        "--mean_disconnection_interval_ms",
         type=float,
         default=float("inf"),
-        help="Mean interval (ms) for dynamic changes (default: inf, for a static network)",
+        help="Mean interval (ms) for disconnection (default: inf, for a static network)",
     )
     parser.add_argument(
-        "--reconnect_interval_ms",
+        "--mean_reconnection_interval_ms",
         type=float,
         default=50,
         help="Mean interval (ms) for node reconnection after disconnection (default: 5000 ms)",
     )
     parser.add_argument(
-        "--disconnect_probability",
+        "--disconnection_probability",
         type=float,
         default=0.1,
-        help="Probability for a node to disconnect in a dynamic change (default: 0.1)",
+        help="Probability for a node to disconnect (default: 0.1)",
     )
     parser.add_argument(
         "--topology_file",
@@ -106,9 +106,9 @@ def setup_arguments():
 def initialize_network(args):
     topology_file_path = os.path.join(os.path.dirname(__file__), args.topology_file)
     network, sender_node = Network.from_yaml(topology_file_path)
-    network.set_mean_interval_ms(args.mean_interval_ms)
-    network.set_reconnect_interval_ms(args.reconnect_interval_ms)
-    network.set_disconnect_probability(args.disconnect_probability)
+    network.set_mean_disconnection_interval_ms(args.mean_disconnection_interval_ms)
+    network.set_mean_reconnection_interval_ms(args.mean_reconnection_interval_ms)
+    network.set_disconnection_probability(args.disconnection_probability)
     return network, sender_node
 
 
@@ -141,9 +141,9 @@ def main():
         max_hops=args.max_hops,
         topology_file=args.topology_file,
         functions_sequence=functions_sequence,
-        mean_interval_ms=args.mean_interval_ms,
-        reconnect_interval_ms=args.reconnect_interval_ms,
-        disconnect_probability=args.disconnect_probability,
+        mean_disconnection_interval_ms=args.mean_disconnection_interval_ms,
+        mean_reconnection_interval_ms=args.mean_reconnection_interval_ms,
+        disconnection_probability=args.disconnection_probability,
         algorithms=[algo.name for algo in selected_algorithms],
         penalty=args.penalty,
     )
@@ -155,7 +155,7 @@ def main():
             f"Running {args.episodes} episodes using the {algorithm.name} algorithm."
         )
         log.info(f"Maximum hops: {args.max_hops}")
-        log.info(f"Mean interval for dynamic changes: {args.mean_interval_ms} ms")
+        log.info(f"Mean interval for dynamic changes: {args.mean_disconnection_interval_ms} ms")
         log.info(f"Topology file: {args.topology_file}")
         log.info(f"Functions sequence: {functions_sequence}")
 

--- a/src/utils/simulation_animator.py
+++ b/src/utils/simulation_animator.py
@@ -101,7 +101,7 @@ def visualize_simulation(simulation_file):
                         f"Reconnect Interval: {data['parameters']['reconnect_interval_ms']} ms\n"
                         f"Topology File: {data['parameters']['topology_file']}\n"
                         f"Functions Sequence: {', '.join(data['parameters']['functions_sequence'])}\n"
-                        f"Disconnect Probability: {data['parameters']['disconnect_probability']}\n\n")
+                        f"Disconnect Probability: {data['parameters']['disconnection_probability']}\n\n")
 
     # Acelerar la animación
     ani = FuncAnimation(fig, update, frames=len(routes), fargs=(nodes, edges, routes, node_functions, algorithm_text), interval=100)


### PR DESCRIPTION
This PR introduces support for fixed intervals in dynamic network behavior, allowing the simulation to operate with deterministic timing for node disconnections and reconnections. This is an alternative to the previously supported stochastic model based on exponential distributions.

# Changes Included
## New args:
- `--disconnection_interval_ms`: Fixed time interval (in milliseconds) between disconnection events.

- `--reconnection_interval_ms`: Fixed duration (in milliseconds) a node remains disconnected before rejoining the network.

## Argument validation:

- The simulation now validates that only one mode (fixed or mean-based) is used at a time.
- Raises `ValueError` if both fixed and mean parameters are provided.

## Updated Network class:

- `generate_next_dynamic_change()` now selects between fixed or mean disconnection interval.

- `_handle_reconnections()` now supports reconnection based on `disconnected_at + reconnection_interval_ms` if using fixed intervals.

## Node model updated:

Nodes now store `disconnected_at` timestamps if fixed reconnection mode is used.